### PR TITLE
fix: include point nation in crossing list

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -45,9 +45,12 @@ const router = createHashRouter([
 
       if (!endorsers) return null;
 
-      return endorsers
-        .filter((endorser) => endorser && endorser !== params.userNation)
-        .reverse();
+      return [
+        params.pointNation,
+        ...endorsers
+          .filter((endorser) => endorser && endorser !== params.userNation)
+          .reverse(),
+      ];
     },
     element: <CrossEndorseSection />,
   },

--- a/src/sections/CrossEndorseSection.tsx
+++ b/src/sections/CrossEndorseSection.tsx
@@ -55,22 +55,21 @@ function UserNationSection() {
         </p>
 
         <div>
-          <div className="mb-1 flex items-center space-x-2">
+          <div className="mb-1 flex items-center">
             <h3
               className="overflow-hidden text-ellipsis whitespace-nowrap font-semibold tracking-tight"
               title={`Nations Endorsing ${prettify(pointNation)}`}
             >
-              Nations Endorsing {prettify(pointNation)}
+              Cross-Endorsing {prettify(pointNation)}
             </h3>
-            {/* <div className="flex-shrink-0 space-x-2 text-sm"> */}
             <button
-              className="h-fit text-sm text-blue-500"
+              className="ml-auto h-fit text-sm text-blue-500"
               onClick={() => setNations(originalNations)}
             >
               Reset
             </button>
             <button
-              className="h-fit text-sm text-blue-500"
+              className="ml-2 h-fit text-sm text-blue-500"
               onClick={() => location.reload()}
             >
               Refresh


### PR DESCRIPTION
This PR includes the point nation at the top of the list of nations to endorse, so that users relying only on CrissCross won't forget to endorse the point nation.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [X] Clearly illustrate what problems this PR would solve.
- [ ] Link related issues or PRs that this PR would close, if any, using `closes #number`.
- [X] Lint and format your code by running `pnpm lint` and `pnpm format`.
