### PR TITLE
Exclude endorsed point

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,7 +21,7 @@ const router = createHashRouter([
     loader: async ({ params }) => {
       // TODO: proper error handling (API error response, no endorsements on point, etc.)
 
-      if (!params.pointNation) return null;
+      if (!params.pointNation || !params.userNation) return null;
 
       const endpoint = new URL("https://www.nationstates.net/cgi-bin/api.cgi");
       endpoint.search = new URLSearchParams({
@@ -45,12 +45,15 @@ const router = createHashRouter([
 
       if (!endorsers) return null;
 
-      return [
-        params.pointNation,
-        ...endorsers
-          .filter((endorser) => endorser && endorser !== params.userNation)
-          .reverse(),
-      ];
+      if (endorsers.includes(params.userNation)) {
+        return [
+          endorsers
+            .filter((endorser) => endorser && endorser !== params.userNation)
+            .reverse(),
+        ];
+      } else {
+        return [params.pointNation, ...endorsers.reverse()];
+      }
     },
     element: <CrossEndorseSection />,
   },

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -46,11 +46,9 @@ const router = createHashRouter([
       if (!endorsers) return null;
 
       if (endorsers.includes(params.userNation)) {
-        return [
-          endorsers
-            .filter((endorser) => endorser && endorser !== params.userNation)
-            .reverse(),
-        ];
+        return endorsers
+          .filter((endorser) => endorser && endorser !== params.userNation)
+          .reverse();
       } else {
         return [params.pointNation, ...endorsers.reverse()];
       }


### PR DESCRIPTION
Including the point nation in the list of nations to endorse (#3) also means that the point nation will always be included, even if already endorsed. This PR adds a check to see if the user has already endorsed the point nation, and includes the point nation only if it's not already endorsed.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [X] Clearly illustrate what problems this PR would solve.
- [ ] Link related issues or PRs that this PR would close, if any, using `closes #number`.
- [X] Lint and format your code by running `pnpm lint` and `pnpm format`.
