### PR TITLE
fix: trim nation name whitespace

### DIFF
--- a/src/utils/nation-names.ts
+++ b/src/utils/nation-names.ts
@@ -1,9 +1,9 @@
 import { titleCase } from "title-case";
 
 export function canonicalize(nation: string) {
-  return nation.toLowerCase().replaceAll(" ", "_");
+  return nation.trim().toLowerCase().replaceAll(/\s+/g, "_");
 }
 
 export function prettify(nation: string) {
-  return titleCase(nation.replaceAll("_", " "));
+  return titleCase(nation.trim().replaceAll("_", " "));
 }


### PR DESCRIPTION
This PR trims leading and trailing whitespace from canonicalized and prettified nation names, and also condenses repeated whitespace into a single underscore when canonicalizing nation names, since nation names currently cannot contain two or more spaces in a row.

Fixes #7.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [X] Clearly illustrate what problems this PR would solve.
- [X] Link related issues or PRs that this PR would close, if any, using `closes #number`.
- [X] Lint and format your code by running `pnpm lint` and `pnpm format`.
