### PR TITLE
chore: update pnpm in CI

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v2
         with:
-          version: 7
+          version: 8
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
This PR updates pnpm to version 8 (it's currently version 7) in GitHub Pages builds, to better match local pnpm versions.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [X] Clearly illustrate what problems this PR would solve.
- [X] Link related issues or PRs that this PR would close, if any, using `closes #number`.
- [X] Lint and format your code by running `pnpm lint` and `pnpm format`.
